### PR TITLE
Updated Cartfile to use RxSwift 5

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "grpc/grpc-swift" == 0.8.1
-github "ReactiveX/RxSwift" == 4.5.0
-binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" == 0.16.0
+github "ReactiveX/RxSwift" ~> 5.0
+binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" == 0.15.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" "0.16.0"
-github "ReactiveX/RxSwift" "4.5.0"
+binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" "0.15.0"
+github "ReactiveX/RxSwift" "5.0.1"
 github "grpc/grpc-swift" "0.8.1"


### PR DESCRIPTION
I have updated RxSwift to 5.0. However, it requires Xcode 10.2 and Swift 5. I was able to build after updating. 

I'd like to note too that I had to downgrade the backend to 0.15.0 for it to work on my end though. I've created an issue [here](https://github.com/Dronecode/DronecodeSDK-Swift/issues/125).
