### PR TITLE
update to backend service

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "jonasvautherin/grpc-swift" "master"
 github "ReactiveX/RxSwift" == 5.0.1
-binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" == 0.18.3
+binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" == 0.20.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,0 @@
-binary "https://s3.eu-central-1.amazonaws.com/dronecode-sdk/backend.json" "0.18.3"
-github "ReactiveX/RxSwift" "5.0.1"
-github "jonasvautherin/grpc-swift" "820730e24b9cf035b2889b30d2fe87411e041720"


### PR DESCRIPTION
When attempting to update the backend I ran into this error after running `bash tools/generate_from_protos.bash`

```
## Generating the SDK wrappers
Traceback (most recent call last):
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/bin/protoc-gen-dcsdk", line 11, in <module>
load_entry_point('protoc-gen-dcsdk', 'console_scripts', 'protoc-gen-dcsdk')()
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/protoc_gen_dcsdk/**main**.py", line 17, in main
AutoGen.generate_reactive(request).SerializeToString())
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/protoc_gen_dcsdk/autogen.py", line 67, in generate_reactive
f.content = str(out_file)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/protoc_gen_dcsdk/autogen_file.py", line 31, in **repr**
has_result=self._has_result)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/asyncsupport.py", line 76, in render
return original_render(self, _args, *_kwargs)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/environment.py", line 1008, in render
return self.environment.handle_exception(exc_info, True)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/environment.py", line 780, in handle_exception
reraise(exc_type, exc_value, tb)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/_compat.py", line 37, in reraise
raise value.with_traceback(tb)
File "/Users/unipheas/Developer/MAVSDK-Swift/tools/../templates/file.j2", line 42, in top-level template code
{{ indent(struct, 1) }}
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/protoc_gen_dcsdk/utils.py", line 78, in jinja_indent
_in_str = str(_in_str)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/protoc_gen_dcsdk/struct.py", line 43, in **repr**
nested_structs=self._nested_structs)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/asyncsupport.py", line 76, in render
return original_render(self, _args, *_kwargs)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/environment.py", line 1008, in render
return self.environment.handle_exception(exc_info, True)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/environment.py", line 780, in handle_exception
reraise(exc_type, exc_value, tb)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/_compat.py", line 37, in reraise
raise value.with_traceback(tb)
File "/Users/unipheas/Developer/MAVSDK-Swift/tools/../templates/struct.j2", line 7, in top-level template code
{{ '\n' + indent(nested_enums[nested_enum], 1) }}
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/protoc_gen_dcsdk/utils.py", line 78, in jinja_indent
_in_str = str(_in_str)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/protoc_gen_dcsdk/enum.py", line 30, in **repr**
parent_struct=self._parent_struct)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/asyncsupport.py", line 76, in render
return original_render(self, _args, *_kwargs)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/environment.py", line 1008, in render
return self.environment.handle_exception(exc_info, True)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/environment.py", line 780, in handle_exception
reraise(exc_type, exc_value, tb)
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/_compat.py", line 37, in reraise
raise value.with_traceback(tb)
File "/Users/unipheas/Developer/MAVSDK-Swift/tools/../templates/enum.j2", line 4, in top-level template code
case {{ value.name.lower_camel_case }}
File "/Users/unipheas/Developer/MAVSDK-Swift/proto/pb_plugins/venv/lib/python3.7/site-packages/jinja2/environment.py", line 430, in getattr
return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'protoc_gen_dcsdk.name_parser.NameParser object' has no attribute 'name'
--custom_out: protoc-gen-custom: Plugin failed with status code 1.
```

Once this is fixed we can merge this in.

