### PR TITLE
Update proto submodule and autogen script

### DIFF
--- a/Sources/MAVSDK-Swift/Generated/Ftp.swift
+++ b/Sources/MAVSDK-Swift/Generated/Ftp.swift
@@ -562,19 +562,19 @@ public class Ftp {
         }
     }
 
-    public func setTargetComponentID(componentID: UInt32) -> Completable {
+    public func setTargetCompid(compid: UInt32) -> Completable {
         return Completable.create { completable in
-            var request = Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest()
+            var request = Mavsdk_Rpc_Ftp_SetTargetCompidRequest()
 
             
                 
-            request.componentID = componentID
+            request.compid = compid
                 
             
 
             do {
                 
-                let response = try self.service.setTargetComponentId(request)
+                let response = try self.service.setTargetCompid(request)
 
                 if (response.ftpResult.result == Mavsdk_Rpc_Ftp_FtpResult.Result.success) {
                     completable(.completed)
@@ -590,20 +590,20 @@ public class Ftp {
         }
     }
 
-    public func getOurComponentID() -> Single<UInt32> {
+    public func getOurCompid() -> Single<UInt32> {
         return Single<UInt32>.create { single in
-            let request = Mavsdk_Rpc_Ftp_GetOurComponentIdRequest()
+            let request = Mavsdk_Rpc_Ftp_GetOurCompidRequest()
 
             
 
             do {
-                let response = try self.service.getOurComponentId(request)
+                let response = try self.service.getOurCompid(request)
 
                 
 
-                let componentID = response.componentID
+                let compid = response.compid
                 
-                single(.success(componentID))
+                single(.success(compid))
             } catch {
                 single(.error(error))
             }

--- a/Sources/MAVSDK-Swift/Generated/Geofence.swift
+++ b/Sources/MAVSDK-Swift/Generated/Geofence.swift
@@ -80,16 +80,16 @@ public class Geofence {
         
 
         public enum FenceType: Equatable {
-            case typeInclusion
-            case typeExclusion
+            case inclusion
+            case exclusion
             case UNRECOGNIZED(Int)
 
             internal var rpcFenceType: Mavsdk_Rpc_Geofence_Polygon.FenceType {
                 switch self {
-                case .typeInclusion:
-                    return .typeInclusion
-                case .typeExclusion:
-                    return .typeExclusion
+                case .inclusion:
+                    return .inclusion
+                case .exclusion:
+                    return .exclusion
                 case .UNRECOGNIZED(let i):
                     return .UNRECOGNIZED(i)
                 }
@@ -97,10 +97,10 @@ public class Geofence {
 
             internal static func translateFromRpc(_ rpcFenceType: Mavsdk_Rpc_Geofence_Polygon.FenceType) -> FenceType {
                 switch rpcFenceType {
-                case .typeInclusion:
-                    return .typeInclusion
-                case .typeExclusion:
-                    return .typeExclusion
+                case .inclusion:
+                    return .inclusion
+                case .exclusion:
+                    return .exclusion
                 case .UNRECOGNIZED(let i):
                     return .UNRECOGNIZED(i)
                 }

--- a/Sources/MAVSDK-Swift/Generated/Gimbal.swift
+++ b/Sources/MAVSDK-Swift/Generated/Gimbal.swift
@@ -75,6 +75,7 @@ public class Gimbal {
             case success
             case error
             case timeout
+            case unsupported
             case UNRECOGNIZED(Int)
 
             internal var rpcResult: Mavsdk_Rpc_Gimbal_GimbalResult.Result {
@@ -87,6 +88,8 @@ public class Gimbal {
                     return .error
                 case .timeout:
                     return .timeout
+                case .unsupported:
+                    return .unsupported
                 case .UNRECOGNIZED(let i):
                     return .UNRECOGNIZED(i)
                 }
@@ -102,6 +105,8 @@ public class Gimbal {
                     return .error
                 case .timeout:
                     return .timeout
+                case .unsupported:
+                    return .unsupported
                 case .UNRECOGNIZED(let i):
                     return .UNRECOGNIZED(i)
                 }

--- a/Sources/MAVSDK-Swift/Generated/Tune.swift
+++ b/Sources/MAVSDK-Swift/Generated/Tune.swift
@@ -203,6 +203,7 @@ public class Tune {
         
 
         public enum Result: Equatable {
+            case unknown
             case success
             case invalidTempo
             case tuneTooLong
@@ -211,6 +212,8 @@ public class Tune {
 
             internal var rpcResult: Mavsdk_Rpc_Tune_TuneResult.Result {
                 switch self {
+                case .unknown:
+                    return .unknown
                 case .success:
                     return .success
                 case .invalidTempo:
@@ -226,6 +229,8 @@ public class Tune {
 
             internal static func translateFromRpc(_ rpcResult: Mavsdk_Rpc_Tune_TuneResult.Result) -> Result {
                 switch rpcResult {
+                case .unknown:
+                    return .unknown
                 case .success:
                     return .success
                 case .invalidTempo:
@@ -273,13 +278,13 @@ public class Tune {
     }
 
 
-    public func playTune(description: TuneDescription) -> Completable {
+    public func playTune(tuneDescription: TuneDescription) -> Completable {
         return Completable.create { completable in
             var request = Mavsdk_Rpc_Tune_PlayTuneRequest()
 
             
                 
-            request.description_p = description.rpcTuneDescription
+            request.tuneDescription = tuneDescription.rpcTuneDescription
                 
             
 

--- a/Sources/MAVSDK-Swift/Generated/ftp.grpc.swift
+++ b/Sources/MAVSDK-Swift/Generated/ftp.grpc.swift
@@ -105,16 +105,16 @@ fileprivate final class Mavsdk_Rpc_Ftp_FtpServiceSetRootDirectoryCallBase: Clien
   override class var method: String { return "/mavsdk.rpc.ftp.FtpService/SetRootDirectory" }
 }
 
-internal protocol Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCall: ClientCallUnary {}
+internal protocol Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCall: ClientCallUnary {}
 
-fileprivate final class Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCallBase: ClientCallUnaryBase<Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse>, Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCall {
-  override class var method: String { return "/mavsdk.rpc.ftp.FtpService/SetTargetComponentId" }
+fileprivate final class Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCallBase: ClientCallUnaryBase<Mavsdk_Rpc_Ftp_SetTargetCompidRequest, Mavsdk_Rpc_Ftp_SetTargetCompidResponse>, Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCall {
+  override class var method: String { return "/mavsdk.rpc.ftp.FtpService/SetTargetCompid" }
 }
 
-internal protocol Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCall: ClientCallUnary {}
+internal protocol Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCall: ClientCallUnary {}
 
-fileprivate final class Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCallBase: ClientCallUnaryBase<Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, Mavsdk_Rpc_Ftp_GetOurComponentIdResponse>, Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCall {
-  override class var method: String { return "/mavsdk.rpc.ftp.FtpService/GetOurComponentId" }
+fileprivate final class Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCallBase: ClientCallUnaryBase<Mavsdk_Rpc_Ftp_GetOurCompidRequest, Mavsdk_Rpc_Ftp_GetOurCompidResponse>, Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCall {
+  override class var method: String { return "/mavsdk.rpc.ftp.FtpService/GetOurCompid" }
 }
 
 
@@ -179,16 +179,16 @@ internal protocol Mavsdk_Rpc_Ftp_FtpServiceService: ServiceClient {
   func setRootDirectory(_ request: Mavsdk_Rpc_Ftp_SetRootDirectoryRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_SetRootDirectoryResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceSetRootDirectoryCall
 
   /// Synchronous. Unary.
-  func setTargetComponentId(_ request: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse
+  func setTargetCompid(_ request: Mavsdk_Rpc_Ftp_SetTargetCompidRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_SetTargetCompidResponse
   /// Asynchronous. Unary.
   @discardableResult
-  func setTargetComponentId(_ request: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCall
+  func setTargetCompid(_ request: Mavsdk_Rpc_Ftp_SetTargetCompidRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_SetTargetCompidResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCall
 
   /// Synchronous. Unary.
-  func getOurComponentId(_ request: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_GetOurComponentIdResponse
+  func getOurCompid(_ request: Mavsdk_Rpc_Ftp_GetOurCompidRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_GetOurCompidResponse
   /// Asynchronous. Unary.
   @discardableResult
-  func getOurComponentId(_ request: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_GetOurComponentIdResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCall
+  func getOurCompid(_ request: Mavsdk_Rpc_Ftp_GetOurCompidRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_GetOurCompidResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCall
 
 }
 
@@ -284,23 +284,23 @@ internal extension Mavsdk_Rpc_Ftp_FtpServiceService {
   }
 
   /// Synchronous. Unary.
-  func setTargetComponentId(_ request: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest) throws -> Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse {
-    return try self.setTargetComponentId(request, metadata: self.metadata)
+  func setTargetCompid(_ request: Mavsdk_Rpc_Ftp_SetTargetCompidRequest) throws -> Mavsdk_Rpc_Ftp_SetTargetCompidResponse {
+    return try self.setTargetCompid(request, metadata: self.metadata)
   }
   /// Asynchronous. Unary.
   @discardableResult
-  func setTargetComponentId(_ request: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, completion: @escaping (Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCall {
-    return try self.setTargetComponentId(request, metadata: self.metadata, completion: completion)
+  func setTargetCompid(_ request: Mavsdk_Rpc_Ftp_SetTargetCompidRequest, completion: @escaping (Mavsdk_Rpc_Ftp_SetTargetCompidResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCall {
+    return try self.setTargetCompid(request, metadata: self.metadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  func getOurComponentId(_ request: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest) throws -> Mavsdk_Rpc_Ftp_GetOurComponentIdResponse {
-    return try self.getOurComponentId(request, metadata: self.metadata)
+  func getOurCompid(_ request: Mavsdk_Rpc_Ftp_GetOurCompidRequest) throws -> Mavsdk_Rpc_Ftp_GetOurCompidResponse {
+    return try self.getOurCompid(request, metadata: self.metadata)
   }
   /// Asynchronous. Unary.
   @discardableResult
-  func getOurComponentId(_ request: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, completion: @escaping (Mavsdk_Rpc_Ftp_GetOurComponentIdResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCall {
-    return try self.getOurComponentId(request, metadata: self.metadata, completion: completion)
+  func getOurCompid(_ request: Mavsdk_Rpc_Ftp_GetOurCompidRequest, completion: @escaping (Mavsdk_Rpc_Ftp_GetOurCompidResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCall {
+    return try self.getOurCompid(request, metadata: self.metadata, completion: completion)
   }
 
 }
@@ -419,26 +419,26 @@ internal final class Mavsdk_Rpc_Ftp_FtpServiceServiceClient: ServiceClientBase, 
   }
 
   /// Synchronous. Unary.
-  internal func setTargetComponentId(_ request: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse {
-    return try Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCallBase(channel)
+  internal func setTargetCompid(_ request: Mavsdk_Rpc_Ftp_SetTargetCompidRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_SetTargetCompidResponse {
+    return try Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCallBase(channel)
       .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
   @discardableResult
-  internal func setTargetComponentId(_ request: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCall {
-    return try Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCallBase(channel)
+  internal func setTargetCompid(_ request: Mavsdk_Rpc_Ftp_SetTargetCompidRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_SetTargetCompidResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCall {
+    return try Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCallBase(channel)
       .start(request: request, metadata: customMetadata, completion: completion)
   }
 
   /// Synchronous. Unary.
-  internal func getOurComponentId(_ request: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_GetOurComponentIdResponse {
-    return try Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCallBase(channel)
+  internal func getOurCompid(_ request: Mavsdk_Rpc_Ftp_GetOurCompidRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_GetOurCompidResponse {
+    return try Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCallBase(channel)
       .run(request: request, metadata: customMetadata)
   }
   /// Asynchronous. Unary.
   @discardableResult
-  internal func getOurComponentId(_ request: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_GetOurComponentIdResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCall {
-    return try Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCallBase(channel)
+  internal func getOurCompid(_ request: Mavsdk_Rpc_Ftp_GetOurCompidRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_GetOurCompidResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCall {
+    return try Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCallBase(channel)
       .start(request: request, metadata: customMetadata, completion: completion)
   }
 
@@ -484,12 +484,12 @@ class Mavsdk_Rpc_Ftp_FtpServiceSetRootDirectoryCallTestStub: ClientCallUnaryTest
   override class var method: String { return "/mavsdk.rpc.ftp.FtpService/SetRootDirectory" }
 }
 
-class Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCallTestStub: ClientCallUnaryTestStub, Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCall {
-  override class var method: String { return "/mavsdk.rpc.ftp.FtpService/SetTargetComponentId" }
+class Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCallTestStub: ClientCallUnaryTestStub, Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCall {
+  override class var method: String { return "/mavsdk.rpc.ftp.FtpService/SetTargetCompid" }
 }
 
-class Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCallTestStub: ClientCallUnaryTestStub, Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCall {
-  override class var method: String { return "/mavsdk.rpc.ftp.FtpService/GetOurComponentId" }
+class Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCallTestStub: ClientCallUnaryTestStub, Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCall {
+  override class var method: String { return "/mavsdk.rpc.ftp.FtpService/GetOurCompid" }
 }
 
 class Mavsdk_Rpc_Ftp_FtpServiceServiceTestStub: ServiceClientTestStubBase, Mavsdk_Rpc_Ftp_FtpServiceService {
@@ -629,34 +629,34 @@ class Mavsdk_Rpc_Ftp_FtpServiceServiceTestStub: ServiceClientTestStubBase, Mavsd
     return Mavsdk_Rpc_Ftp_FtpServiceSetRootDirectoryCallTestStub()
   }
 
-  var setTargetComponentIdRequests: [Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest] = []
-  var setTargetComponentIdResponses: [Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse] = []
-  func setTargetComponentId(_ request: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse {
-    setTargetComponentIdRequests.append(request)
-    defer { setTargetComponentIdResponses.removeFirst() }
-    return setTargetComponentIdResponses.first!
+  var setTargetCompidRequests: [Mavsdk_Rpc_Ftp_SetTargetCompidRequest] = []
+  var setTargetCompidResponses: [Mavsdk_Rpc_Ftp_SetTargetCompidResponse] = []
+  func setTargetCompid(_ request: Mavsdk_Rpc_Ftp_SetTargetCompidRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_SetTargetCompidResponse {
+    setTargetCompidRequests.append(request)
+    defer { setTargetCompidResponses.removeFirst() }
+    return setTargetCompidResponses.first!
   }
   @discardableResult
-  func setTargetComponentId(_ request: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCall {
-    let response = try self.setTargetComponentId(request)
+  func setTargetCompid(_ request: Mavsdk_Rpc_Ftp_SetTargetCompidRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_SetTargetCompidResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCall {
+    let response = try self.setTargetCompid(request)
     let callResult = CallResult(success: true, statusCode: .ok, statusMessage: "OK", resultData: nil, initialMetadata: nil, trailingMetadata: nil)
     completion(response, callResult)
-    return Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdCallTestStub()
+    return Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidCallTestStub()
   }
 
-  var getOurComponentIdRequests: [Mavsdk_Rpc_Ftp_GetOurComponentIdRequest] = []
-  var getOurComponentIdResponses: [Mavsdk_Rpc_Ftp_GetOurComponentIdResponse] = []
-  func getOurComponentId(_ request: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_GetOurComponentIdResponse {
-    getOurComponentIdRequests.append(request)
-    defer { getOurComponentIdResponses.removeFirst() }
-    return getOurComponentIdResponses.first!
+  var getOurCompidRequests: [Mavsdk_Rpc_Ftp_GetOurCompidRequest] = []
+  var getOurCompidResponses: [Mavsdk_Rpc_Ftp_GetOurCompidResponse] = []
+  func getOurCompid(_ request: Mavsdk_Rpc_Ftp_GetOurCompidRequest, metadata customMetadata: Metadata) throws -> Mavsdk_Rpc_Ftp_GetOurCompidResponse {
+    getOurCompidRequests.append(request)
+    defer { getOurCompidResponses.removeFirst() }
+    return getOurCompidResponses.first!
   }
   @discardableResult
-  func getOurComponentId(_ request: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_GetOurComponentIdResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCall {
-    let response = try self.getOurComponentId(request)
+  func getOurCompid(_ request: Mavsdk_Rpc_Ftp_GetOurCompidRequest, metadata customMetadata: Metadata, completion: @escaping (Mavsdk_Rpc_Ftp_GetOurCompidResponse?, CallResult) -> Void) throws -> Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCall {
+    let response = try self.getOurCompid(request)
     let callResult = CallResult(success: true, statusCode: .ok, statusMessage: "OK", resultData: nil, initialMetadata: nil, trailingMetadata: nil)
     completion(response, callResult)
-    return Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdCallTestStub()
+    return Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidCallTestStub()
   }
 
 }
@@ -675,8 +675,8 @@ internal protocol Mavsdk_Rpc_Ftp_FtpServiceProvider: ServiceProvider {
   func rename(request: Mavsdk_Rpc_Ftp_RenameRequest, session: Mavsdk_Rpc_Ftp_FtpServiceRenameSession) throws -> Mavsdk_Rpc_Ftp_RenameResponse
   func areFilesIdentical(request: Mavsdk_Rpc_Ftp_AreFilesIdenticalRequest, session: Mavsdk_Rpc_Ftp_FtpServiceAreFilesIdenticalSession) throws -> Mavsdk_Rpc_Ftp_AreFilesIdenticalResponse
   func setRootDirectory(request: Mavsdk_Rpc_Ftp_SetRootDirectoryRequest, session: Mavsdk_Rpc_Ftp_FtpServiceSetRootDirectorySession) throws -> Mavsdk_Rpc_Ftp_SetRootDirectoryResponse
-  func setTargetComponentId(request: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, session: Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdSession) throws -> Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse
-  func getOurComponentId(request: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, session: Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdSession) throws -> Mavsdk_Rpc_Ftp_GetOurComponentIdResponse
+  func setTargetCompid(request: Mavsdk_Rpc_Ftp_SetTargetCompidRequest, session: Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidSession) throws -> Mavsdk_Rpc_Ftp_SetTargetCompidResponse
+  func getOurCompid(request: Mavsdk_Rpc_Ftp_GetOurCompidRequest, session: Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidSession) throws -> Mavsdk_Rpc_Ftp_GetOurCompidResponse
 }
 
 extension Mavsdk_Rpc_Ftp_FtpServiceProvider {
@@ -736,15 +736,15 @@ extension Mavsdk_Rpc_Ftp_FtpServiceProvider {
         handler: handler,
         providerBlock: { try self.setRootDirectory(request: $0, session: $1 as! Mavsdk_Rpc_Ftp_FtpServiceSetRootDirectorySessionBase) })
           .run()
-    case "/mavsdk.rpc.ftp.FtpService/SetTargetComponentId":
-      return try Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdSessionBase(
+    case "/mavsdk.rpc.ftp.FtpService/SetTargetCompid":
+      return try Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidSessionBase(
         handler: handler,
-        providerBlock: { try self.setTargetComponentId(request: $0, session: $1 as! Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdSessionBase) })
+        providerBlock: { try self.setTargetCompid(request: $0, session: $1 as! Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidSessionBase) })
           .run()
-    case "/mavsdk.rpc.ftp.FtpService/GetOurComponentId":
-      return try Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdSessionBase(
+    case "/mavsdk.rpc.ftp.FtpService/GetOurCompid":
+      return try Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidSessionBase(
         handler: handler,
-        providerBlock: { try self.getOurComponentId(request: $0, session: $1 as! Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdSessionBase) })
+        providerBlock: { try self.getOurCompid(request: $0, session: $1 as! Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidSessionBase) })
           .run()
     default:
       throw HandleMethodError.unknownMethod
@@ -842,15 +842,15 @@ fileprivate final class Mavsdk_Rpc_Ftp_FtpServiceSetRootDirectorySessionBase: Se
 
 class Mavsdk_Rpc_Ftp_FtpServiceSetRootDirectorySessionTestStub: ServerSessionUnaryTestStub, Mavsdk_Rpc_Ftp_FtpServiceSetRootDirectorySession {}
 
-internal protocol Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdSession: ServerSessionUnary {}
+internal protocol Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidSession: ServerSessionUnary {}
 
-fileprivate final class Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdSessionBase: ServerSessionUnaryBase<Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse>, Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdSession {}
+fileprivate final class Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidSessionBase: ServerSessionUnaryBase<Mavsdk_Rpc_Ftp_SetTargetCompidRequest, Mavsdk_Rpc_Ftp_SetTargetCompidResponse>, Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidSession {}
 
-class Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdSessionTestStub: ServerSessionUnaryTestStub, Mavsdk_Rpc_Ftp_FtpServiceSetTargetComponentIdSession {}
+class Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidSessionTestStub: ServerSessionUnaryTestStub, Mavsdk_Rpc_Ftp_FtpServiceSetTargetCompidSession {}
 
-internal protocol Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdSession: ServerSessionUnary {}
+internal protocol Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidSession: ServerSessionUnary {}
 
-fileprivate final class Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdSessionBase: ServerSessionUnaryBase<Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, Mavsdk_Rpc_Ftp_GetOurComponentIdResponse>, Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdSession {}
+fileprivate final class Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidSessionBase: ServerSessionUnaryBase<Mavsdk_Rpc_Ftp_GetOurCompidRequest, Mavsdk_Rpc_Ftp_GetOurCompidResponse>, Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidSession {}
 
-class Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdSessionTestStub: ServerSessionUnaryTestStub, Mavsdk_Rpc_Ftp_FtpServiceGetOurComponentIdSession {}
+class Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidSessionTestStub: ServerSessionUnaryTestStub, Mavsdk_Rpc_Ftp_FtpServiceGetOurCompidSession {}
 

--- a/Sources/MAVSDK-Swift/Generated/ftp.pb.swift
+++ b/Sources/MAVSDK-Swift/Generated/ftp.pb.swift
@@ -400,20 +400,20 @@ struct Mavsdk_Rpc_Ftp_SetRootDirectoryResponse {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest {
+struct Mavsdk_Rpc_Ftp_SetTargetCompidRequest {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The component ID to set.
-  var componentID: UInt32 = 0
+  var compid: UInt32 = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 }
 
-struct Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse {
+struct Mavsdk_Rpc_Ftp_SetTargetCompidResponse {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -434,7 +434,7 @@ struct Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-struct Mavsdk_Rpc_Ftp_GetOurComponentIdRequest {
+struct Mavsdk_Rpc_Ftp_GetOurCompidRequest {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -444,13 +444,13 @@ struct Mavsdk_Rpc_Ftp_GetOurComponentIdRequest {
   init() {}
 }
 
-struct Mavsdk_Rpc_Ftp_GetOurComponentIdResponse {
+struct Mavsdk_Rpc_Ftp_GetOurCompidResponse {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// Our component ID.
-  var componentID: UInt32 = 0
+  var compid: UInt32 = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1546,37 +1546,37 @@ extension Mavsdk_Rpc_Ftp_SetRootDirectoryResponse: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  static let protoMessageName: String = _protobuf_package + ".SetTargetComponentIdRequest"
+extension Mavsdk_Rpc_Ftp_SetTargetCompidRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".SetTargetCompidRequest"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "component_id"),
+    1: .same(proto: "compid"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       switch fieldNumber {
-      case 1: try decoder.decodeSingularUInt32Field(value: &self.componentID)
+      case 1: try decoder.decodeSingularUInt32Field(value: &self.compid)
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.componentID != 0 {
-      try visitor.visitSingularUInt32Field(value: self.componentID, fieldNumber: 1)
+    if self.compid != 0 {
+      try visitor.visitSingularUInt32Field(value: self.compid, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest, rhs: Mavsdk_Rpc_Ftp_SetTargetComponentIdRequest) -> Bool {
-    if lhs.componentID != rhs.componentID {return false}
+  static func ==(lhs: Mavsdk_Rpc_Ftp_SetTargetCompidRequest, rhs: Mavsdk_Rpc_Ftp_SetTargetCompidRequest) -> Bool {
+    if lhs.compid != rhs.compid {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  static let protoMessageName: String = _protobuf_package + ".SetTargetComponentIdResponse"
+extension Mavsdk_Rpc_Ftp_SetTargetCompidResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".SetTargetCompidResponse"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "ftp_result"),
   ]
@@ -1621,7 +1621,7 @@ extension Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse: SwiftProtobuf.Message, Sw
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse, rhs: Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse) -> Bool {
+  static func ==(lhs: Mavsdk_Rpc_Ftp_SetTargetCompidResponse, rhs: Mavsdk_Rpc_Ftp_SetTargetCompidResponse) -> Bool {
     if lhs._storage !== rhs._storage {
       let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
         let _storage = _args.0
@@ -1636,8 +1636,8 @@ extension Mavsdk_Rpc_Ftp_SetTargetComponentIdResponse: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Mavsdk_Rpc_Ftp_GetOurComponentIdRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  static let protoMessageName: String = _protobuf_package + ".GetOurComponentIdRequest"
+extension Mavsdk_Rpc_Ftp_GetOurCompidRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".GetOurCompidRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1649,36 +1649,36 @@ extension Mavsdk_Rpc_Ftp_GetOurComponentIdRequest: SwiftProtobuf.Message, SwiftP
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest, rhs: Mavsdk_Rpc_Ftp_GetOurComponentIdRequest) -> Bool {
+  static func ==(lhs: Mavsdk_Rpc_Ftp_GetOurCompidRequest, rhs: Mavsdk_Rpc_Ftp_GetOurCompidRequest) -> Bool {
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Mavsdk_Rpc_Ftp_GetOurComponentIdResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  static let protoMessageName: String = _protobuf_package + ".GetOurComponentIdResponse"
+extension Mavsdk_Rpc_Ftp_GetOurCompidResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".GetOurCompidResponse"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "component_id"),
+    1: .same(proto: "compid"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       switch fieldNumber {
-      case 1: try decoder.decodeSingularUInt32Field(value: &self.componentID)
+      case 1: try decoder.decodeSingularUInt32Field(value: &self.compid)
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.componentID != 0 {
-      try visitor.visitSingularUInt32Field(value: self.componentID, fieldNumber: 1)
+    if self.compid != 0 {
+      try visitor.visitSingularUInt32Field(value: self.compid, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  static func ==(lhs: Mavsdk_Rpc_Ftp_GetOurComponentIdResponse, rhs: Mavsdk_Rpc_Ftp_GetOurComponentIdResponse) -> Bool {
-    if lhs.componentID != rhs.componentID {return false}
+  static func ==(lhs: Mavsdk_Rpc_Ftp_GetOurCompidResponse, rhs: Mavsdk_Rpc_Ftp_GetOurCompidResponse) -> Bool {
+    if lhs.compid != rhs.compid {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/MAVSDK-Swift/Generated/geofence.pb.swift
+++ b/Sources/MAVSDK-Swift/Generated/geofence.pb.swift
@@ -46,7 +46,7 @@ struct Mavsdk_Rpc_Geofence_Polygon {
   var points: [Mavsdk_Rpc_Geofence_Point] = []
 
   /// Fence type
-  var fenceType: Mavsdk_Rpc_Geofence_Polygon.FenceType = .typeInclusion
+  var fenceType: Mavsdk_Rpc_Geofence_Polygon.FenceType = .inclusion
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -55,28 +55,28 @@ struct Mavsdk_Rpc_Geofence_Polygon {
     typealias RawValue = Int
 
     /// Type representing an inclusion fence
-    case typeInclusion // = 0
+    case inclusion // = 0
 
     /// Type representing an exclusion fence
-    case typeExclusion // = 1
+    case exclusion // = 1
     case UNRECOGNIZED(Int)
 
     init() {
-      self = .typeInclusion
+      self = .inclusion
     }
 
     init?(rawValue: Int) {
       switch rawValue {
-      case 0: self = .typeInclusion
-      case 1: self = .typeExclusion
+      case 0: self = .inclusion
+      case 1: self = .exclusion
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
-      case .typeInclusion: return 0
-      case .typeExclusion: return 1
+      case .inclusion: return 0
+      case .exclusion: return 1
       case .UNRECOGNIZED(let i): return i
       }
     }
@@ -91,8 +91,8 @@ struct Mavsdk_Rpc_Geofence_Polygon {
 extension Mavsdk_Rpc_Geofence_Polygon.FenceType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static var allCases: [Mavsdk_Rpc_Geofence_Polygon.FenceType] = [
-    .typeInclusion,
-    .typeExclusion,
+    .inclusion,
+    .exclusion,
   ]
 }
 
@@ -284,7 +284,7 @@ extension Mavsdk_Rpc_Geofence_Polygon: SwiftProtobuf.Message, SwiftProtobuf._Mes
     if !self.points.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.points, fieldNumber: 1)
     }
-    if self.fenceType != .typeInclusion {
+    if self.fenceType != .inclusion {
       try visitor.visitSingularEnumField(value: self.fenceType, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -300,8 +300,8 @@ extension Mavsdk_Rpc_Geofence_Polygon: SwiftProtobuf.Message, SwiftProtobuf._Mes
 
 extension Mavsdk_Rpc_Geofence_Polygon.FenceType: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "TYPE_INCLUSION"),
-    1: .same(proto: "TYPE_EXCLUSION"),
+    0: .same(proto: "FENCE_TYPE_INCLUSION"),
+    1: .same(proto: "FENCE_TYPE_EXCLUSION"),
   ]
 }
 

--- a/Sources/MAVSDK-Swift/Generated/gimbal.pb.swift
+++ b/Sources/MAVSDK-Swift/Generated/gimbal.pb.swift
@@ -204,6 +204,9 @@ struct Mavsdk_Rpc_Gimbal_GimbalResult {
 
     /// Command timed out
     case timeout // = 3
+
+    /// Functionality not supported
+    case unsupported // = 4
     case UNRECOGNIZED(Int)
 
     init() {
@@ -216,6 +219,7 @@ struct Mavsdk_Rpc_Gimbal_GimbalResult {
       case 1: self = .success
       case 2: self = .error
       case 3: self = .timeout
+      case 4: self = .unsupported
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
@@ -226,6 +230,7 @@ struct Mavsdk_Rpc_Gimbal_GimbalResult {
       case .success: return 1
       case .error: return 2
       case .timeout: return 3
+      case .unsupported: return 4
       case .UNRECOGNIZED(let i): return i
       }
     }
@@ -244,6 +249,7 @@ extension Mavsdk_Rpc_Gimbal_GimbalResult.Result: CaseIterable {
     .success,
     .error,
     .timeout,
+    .unsupported,
   ]
 }
 
@@ -589,5 +595,6 @@ extension Mavsdk_Rpc_Gimbal_GimbalResult.Result: SwiftProtobuf._ProtoNameProvidi
     1: .same(proto: "RESULT_SUCCESS"),
     2: .same(proto: "RESULT_ERROR"),
     3: .same(proto: "RESULT_TIMEOUT"),
+    4: .same(proto: "RESULT_UNSUPPORTED"),
   ]
 }

--- a/Sources/MAVSDK-Swift/Generated/tune.pb.swift
+++ b/Sources/MAVSDK-Swift/Generated/tune.pb.swift
@@ -184,14 +184,14 @@ struct Mavsdk_Rpc_Tune_PlayTuneRequest {
   // methods supported on all messages.
 
   /// The tune to be played
-  var description_p: Mavsdk_Rpc_Tune_TuneDescription {
-    get {return _storage._description_p ?? Mavsdk_Rpc_Tune_TuneDescription()}
-    set {_uniqueStorage()._description_p = newValue}
+  var tuneDescription: Mavsdk_Rpc_Tune_TuneDescription {
+    get {return _storage._tuneDescription ?? Mavsdk_Rpc_Tune_TuneDescription()}
+    set {_uniqueStorage()._tuneDescription = newValue}
   }
-  /// Returns true if `description_p` has been explicitly set.
-  var hasDescription_p: Bool {return _storage._description_p != nil}
-  /// Clears the value of `description_p`. Subsequent reads from it will return its default value.
-  mutating func clearDescription_p() {_uniqueStorage()._description_p = nil}
+  /// Returns true if `tuneDescription` has been explicitly set.
+  var hasTuneDescription: Bool {return _storage._tuneDescription != nil}
+  /// Clears the value of `tuneDescription`. Subsequent reads from it will return its default value.
+  mutating func clearTuneDescription() {_uniqueStorage()._tuneDescription = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -244,7 +244,7 @@ struct Mavsdk_Rpc_Tune_TuneResult {
   // methods supported on all messages.
 
   /// Result enum value
-  var result: Mavsdk_Rpc_Tune_TuneResult.Result = .success
+  var result: Mavsdk_Rpc_Tune_TuneResult.Result = .unknown
 
   /// Human-readable English string describing the result
   var resultStr: String = String()
@@ -255,39 +255,44 @@ struct Mavsdk_Rpc_Tune_TuneResult {
   enum Result: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
+    /// Unknown result
+    case unknown // = 0
+
     /// Request succeeded
-    case success // = 0
+    case success // = 1
 
     /// Invalid tempo (range: 32 - 255)
-    case invalidTempo // = 1
+    case invalidTempo // = 2
 
     /// Invalid tune: encoded string must be at most 247 chars
-    case tuneTooLong // = 2
+    case tuneTooLong // = 3
 
     /// Failed to send the request
-    case error // = 3
+    case error // = 4
     case UNRECOGNIZED(Int)
 
     init() {
-      self = .success
+      self = .unknown
     }
 
     init?(rawValue: Int) {
       switch rawValue {
-      case 0: self = .success
-      case 1: self = .invalidTempo
-      case 2: self = .tuneTooLong
-      case 3: self = .error
+      case 0: self = .unknown
+      case 1: self = .success
+      case 2: self = .invalidTempo
+      case 3: self = .tuneTooLong
+      case 4: self = .error
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
-      case .success: return 0
-      case .invalidTempo: return 1
-      case .tuneTooLong: return 2
-      case .error: return 3
+      case .unknown: return 0
+      case .success: return 1
+      case .invalidTempo: return 2
+      case .tuneTooLong: return 3
+      case .error: return 4
       case .UNRECOGNIZED(let i): return i
       }
     }
@@ -302,6 +307,7 @@ struct Mavsdk_Rpc_Tune_TuneResult {
 extension Mavsdk_Rpc_Tune_TuneResult.Result: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   static var allCases: [Mavsdk_Rpc_Tune_TuneResult.Result] = [
+    .unknown,
     .success,
     .invalidTempo,
     .tuneTooLong,
@@ -344,18 +350,18 @@ extension Mavsdk_Rpc_Tune_SongElement: SwiftProtobuf._ProtoNameProviding {
 extension Mavsdk_Rpc_Tune_PlayTuneRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PlayTuneRequest"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "description"),
+    1: .standard(proto: "tune_description"),
   ]
 
   fileprivate class _StorageClass {
-    var _description_p: Mavsdk_Rpc_Tune_TuneDescription? = nil
+    var _tuneDescription: Mavsdk_Rpc_Tune_TuneDescription? = nil
 
     static let defaultInstance = _StorageClass()
 
     private init() {}
 
     init(copying source: _StorageClass) {
-      _description_p = source._description_p
+      _tuneDescription = source._tuneDescription
     }
   }
 
@@ -371,7 +377,7 @@ extension Mavsdk_Rpc_Tune_PlayTuneRequest: SwiftProtobuf.Message, SwiftProtobuf.
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
       while let fieldNumber = try decoder.nextFieldNumber() {
         switch fieldNumber {
-        case 1: try decoder.decodeSingularMessageField(value: &_storage._description_p)
+        case 1: try decoder.decodeSingularMessageField(value: &_storage._tuneDescription)
         default: break
         }
       }
@@ -380,7 +386,7 @@ extension Mavsdk_Rpc_Tune_PlayTuneRequest: SwiftProtobuf.Message, SwiftProtobuf.
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._description_p {
+      if let v = _storage._tuneDescription {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
       }
     }
@@ -392,7 +398,7 @@ extension Mavsdk_Rpc_Tune_PlayTuneRequest: SwiftProtobuf.Message, SwiftProtobuf.
       let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
         let _storage = _args.0
         let rhs_storage = _args.1
-        if _storage._description_p != rhs_storage._description_p {return false}
+        if _storage._tuneDescription != rhs_storage._tuneDescription {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -516,7 +522,7 @@ extension Mavsdk_Rpc_Tune_TuneResult: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.result != .success {
+    if self.result != .unknown {
       try visitor.visitSingularEnumField(value: self.result, fieldNumber: 1)
     }
     if !self.resultStr.isEmpty {
@@ -535,9 +541,10 @@ extension Mavsdk_Rpc_Tune_TuneResult: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
 extension Mavsdk_Rpc_Tune_TuneResult.Result: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "RESULT_SUCCESS"),
-    1: .same(proto: "RESULT_INVALID_TEMPO"),
-    2: .same(proto: "RESULT_TUNE_TOO_LONG"),
-    3: .same(proto: "RESULT_ERROR"),
+    0: .same(proto: "RESULT_UNKNOWN"),
+    1: .same(proto: "RESULT_SUCCESS"),
+    2: .same(proto: "RESULT_INVALID_TEMPO"),
+    3: .same(proto: "RESULT_TUNE_TOO_LONG"),
+    4: .same(proto: "RESULT_ERROR"),
   ]
 }

--- a/tools/generate_from_protos.bash
+++ b/tools/generate_from_protos.bash
@@ -4,6 +4,18 @@ set -e
 
 command -v protoc || { echo >&2 "Protobuf needs to be installed (e.g. '$ brew install protobuf') for this script to run!"; exit 1; }
 
+command -v protoc-gen-mavsdk > /dev/null || {
+    echo "------------------------"
+    echo "Error"
+    echo "------------------------"
+    echo >&2 "'protoc-gen-mavsdk' not found in PATH"
+    echo >&2 ""
+    echo >&2 "You can install it using pip:"
+    echo >&2 ""
+    echo >&2 "pip3 install protoc-gen-mavsdk"
+    exit 1
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PB_PLUGINS_DIR=${PB_PLUGINS_DIR:-"${SCRIPT_DIR}/../proto/pb_plugins"}
 PROTO_DIR=${PROTO_DIR:-"${SCRIPT_DIR}/../proto/protos"}
@@ -52,17 +64,8 @@ echo "Generating the SDK wrappers"
 echo "-------------------------------"
 echo ""
 
-if [ ! -d ${PB_PLUGINS_DIR}/venv ]; then
-    python3 -m venv ${PB_PLUGINS_DIR}/venv
-
-    source ${PB_PLUGINS_DIR}/venv/bin/activate
-    pip install -r ${PB_PLUGINS_DIR}/requirements.txt
-    pip install -e ${PB_PLUGINS_DIR}
-fi
-
-source ${PB_PLUGINS_DIR}/venv/bin/activate
 export TEMPLATE_PATH=${TEMPLATE_PATH:-"${SCRIPT_DIR}/../templates"}
 
 for plugin in ${PLUGIN_LIST}; do
-    protoc ${plugin}.proto --plugin=protoc-gen-custom=$(which protoc-gen-dcsdk) -I${PROTO_DIR}  -I${PROTO_DIR}/${plugin} --custom_out=${OUTPUT_DIR} --custom_opt=file_ext=swift
+    protoc ${plugin}.proto --plugin=protoc-gen-custom=$(which protoc-gen-mavsdk) -I${PROTO_DIR}  -I${PROTO_DIR}/${plugin} --custom_out=${OUTPUT_DIR} --custom_opt=file_ext=swift
 done


### PR DESCRIPTION
I had to change "component_id" for "compid" because the Swift protobuf plugin apparently can't make its mind on whether it should use "ID" or "Id", and is inconsistent.

Also this moves to using `protoc-gen-mavsdk` (renamed from `protoc-gen-dcsdk`), and expecting it to be installed from pip (`pip3 install protoc-gen-mavsdk`) instead of installing it from sources.