### PR TITLE
Add support for Linux

### DIFF
--- a/Sources/MavsdkServer/MavsdkServer.swift
+++ b/Sources/MavsdkServer/MavsdkServer.swift
@@ -1,3 +1,4 @@
+#if !os(Linux)
 import Foundation
 import RxSwift
 import mavsdk_server
@@ -39,3 +40,4 @@ public class MavsdkServer {
         mavsdk_server_stop(self.mavsdkServerHandle!)
     }
 }
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,4 @@
+import XCTest
+
+var tests = [XCTestCaseEntry]()
+XCTMain(tests)


### PR DESCRIPTION
With this change, it is possible to use the gRPC client in Linux, but `MavsdkServer.swift` won't work (because it relies on an XCFramework). This implies that `mavsdk_server` must be started manually, and the `Drone` object can be created as follows:

```
let drone = Drone(address: mavsdk_server_address, port: 50051)
```

where `mavsdk_server_address` is the IP where `mavsdk_server` is running.