### PR TITLE
Add github workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,46 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - 'master'
+    tags:
+    - '*'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    name: build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: build
+        run: swift build
+  generate-from-proto:
+    name: generate from protos
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: install tools
+        run: pip3 install protoc-gen-mavsdk && brew install protobuf
+      - name: generate from protos
+        run: bash Sources/MAVSDK-Swift/tools/generate_from_protos.bash
+      - name: check for diff
+        run: git diff --exit-code
+  generate-docs:
+    name: generate documentation
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: install tools
+        run: gem install jazzy
+      - name: generate docs
+        run: bash Sources/MAVSDK-Swift/tools/generate_docs.sh


### PR DESCRIPTION
This adds a CI running the following jobs:

* Build on macOS (`swift build`)
* Generate the documentation (via the `generate_docs.sh` script)
* Generate the code from the proto files and check that it is consistent with the `Generated/` code. If not, it means that the proto submodule is wrong or that the code should be generated.

@kylewludwig FYI